### PR TITLE
Update specialization from AI Search to Domain Specific Copilots

### DIFF
--- a/src/pages/about-us.mdx
+++ b/src/pages/about-us.mdx
@@ -22,7 +22,7 @@ Vertexcover Labs is an AI-native engineering studio that partners with **seed-fu
     }
   },
   {
-    title: "AI Search",
+    title: "Domain Specific Copilots",
     description: "RAG, Semantic Search, Hybrid Search, Knowledge Graphs - Advanced information retrieval systems that understand context and meaning.",
     icon: "🔍",
     color: {


### PR DESCRIPTION
## Summary
- Updated the expertise area title on the about-us page
- Changed "AI Search" to "Domain Specific Copilots" to better reflect the focus on building domain-specific AI assistants

## Test plan
- [x] Built the project successfully with `bun run build`
- [x] No TypeScript or build errors

🤖 Generated with [Claude Code](https://claude.ai/code)